### PR TITLE
Update plugin description to reflect all dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # Quote of the Day
 
 **Plugin Name:** Quote of the Day  
-**Description:** A plugin to display the quote of the day with a calendar to pick previous dates.  
+**Description:** A plugin to display the quote of the day with a calendar to pick all dates.  
 **Version:** 1.0  
 **Author:** Tarek Nabil
 
 ## Description
 
-The "Quote of the Day" plugin allows you to display a quote of the day from a custom post type. Users can select a date from a calendar to view quotes from previous dates. The plugin integrates with Elementor to provide a custom widget for displaying the quotes.
+The "Quote of the Day" plugin allows you to display a quote of the day from a custom post type. Users can select a date from a calendar to view quotes from all dates. The plugin integrates with Elementor to provide a custom widget for displaying the quotes.
 
 ## Features
 
 - Custom post type for quotes
 - Shortcode to display the quote of the day
-- jQuery UI datepicker to select previous dates
+- jQuery UI datepicker to select all dates
 - Elementor widget for easy integration
 
 ## Installation
@@ -31,7 +31,7 @@ Use the `[quote_of_the_day]` shortcode to display the quote of the day. The shor
 
 ### Elementor Widget
 
-The plugin provides an Elementor widget named "Quote of the Day". You can add this widget to any page using the Elementor editor. The widget will display the quote of the day with a datepicker to select previous dates.
+The plugin provides an Elementor widget named "Quote of the Day". You can add this widget to any page using the Elementor editor. The widget will display the quote of the day with a datepicker to select all dates.
 
 ## Custom Post Type
 

--- a/quote-of-the-day.php
+++ b/quote-of-the-day.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: Quote of the Day
-Description: A plugin to display the quote of the day with a calendar to pick previous dates.
+Description: A plugin to display the quote of the day with a calendar to pick all dates.
 Version: 1.0
 Author: Tarek Nabil
 */


### PR DESCRIPTION
Fixes #2

Update the plugin description to indicate that it shows all dates.

* **README.md**
  - Update the description to state that the plugin displays the quote of the day with a calendar to pick all dates.
  - Update the usage section to reflect that users can select any date using the datepicker.
  - Update the Elementor widget description to mention selecting all dates.

* **quote-of-the-day.php**
  - Update the plugin description to mention displaying the quote of the day with a calendar to pick all dates.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/TarekNabil/Quote-Of-The-Day/pull/3?shareId=f4e78176-e61b-4781-8204-13f99e3c6f62).